### PR TITLE
Fix for incompatible encoding errors

### DIFF
--- a/lib/wayback_machine_downloader.rb
+++ b/lib/wayback_machine_downloader.rb
@@ -201,7 +201,7 @@ class WaybackMachineDownloader
   end
 
   def download_file file_remote_info
-    file_url = file_remote_info[:file_url]
+    file_url = file_remote_info[:file_url].encode(''.encoding)
     file_id = file_remote_info[:file_id]
     file_timestamp = file_remote_info[:timestamp]
     file_path_elements = file_id.split('/')

--- a/test/test_wayback_machine_downloader.rb
+++ b/test/test_wayback_machine_downloader.rb
@@ -89,5 +89,14 @@ class WaybackMachineDownloaderTest < Minitest::Test
     @wayback_machine_downloader.all = true
     assert_equal 69, @wayback_machine_downloader.get_file_list_curated.size
   end
+ 
+  # Testing encoding conflicts needs a different base_url
+  def test_nonascii_suburls_download
+    @wayback_machine_downloader = WaybackMachineDownloader.new base_url: 'https://en.wikipedia.org/wiki/%C3%84'
+    # Once for the downloading...
+    @wayback_machine_downloader.download_files
+    # ... and once for the "is already present"
+    @wayback_machine_downloader.download_files
+  end
 
 end

--- a/test/test_wayback_machine_downloader.rb
+++ b/test/test_wayback_machine_downloader.rb
@@ -93,9 +93,14 @@ class WaybackMachineDownloaderTest < Minitest::Test
   # Testing encoding conflicts needs a different base_url
   def test_nonascii_suburls_download
     @wayback_machine_downloader = WaybackMachineDownloader.new base_url: 'https://en.wikipedia.org/wiki/%C3%84'
-    # Once for the downloading...
+    # Once just for the downloading...
     @wayback_machine_downloader.download_files
-    # ... and once for the "is already present"
+  end
+
+  def test_nonascii_suburls_already_present
+    @wayback_machine_downloader = WaybackMachineDownloader.new base_url: 'https://en.wikipedia.org/wiki/%C3%84'
+    # ... twice to test the "is already present" case
+    @wayback_machine_downloader.download_files
     @wayback_machine_downloader.download_files
   end
 


### PR DESCRIPTION
Fixes: #72, probably also #70.

This *probably* also prevents further problems that could arise from anywhere else string interpolation happens involving `file_url` and other strings.