### PR TITLE
Move internal modules under WaybackMachineDownloader namespace

### DIFF
--- a/lib/wayback_machine_downloader/archive_api.rb
+++ b/lib/wayback_machine_downloader/archive_api.rb
@@ -1,4 +1,6 @@
-module ArchiveAPI
+class WaybackMachineDownloader; end
+
+module WaybackMachineDownloader::ArchiveAPI
 
   def get_raw_list_from_api url, page_index
     request_url = "http://web.archive.org/cdx/search/xd?url="

--- a/lib/wayback_machine_downloader/tidy_bytes.rb
+++ b/lib/wayback_machine_downloader/tidy_bytes.rb
@@ -1,4 +1,4 @@
-module TibyBytes
+module TidyBytes
 
   # CP-1252 decimal byte => UTF-8 approximation as an array of bytes
   CP1252 = {
@@ -111,12 +111,12 @@ module TibyBytes
     private
 
     def tidy_byte(byte)
-      byte < 160 ? TibyBytes::CP1252[byte] : byte < 192 ? [194, byte] : [195, byte - 64]
+      byte < 160 ? TidyBytes::CP1252[byte] : byte < 192 ? [194, byte] : [195, byte - 64]
     end
 
   end
 end
 
 class String
-  include TibyBytes::StringMixin
+  include TidyBytes::StringMixin
 end

--- a/lib/wayback_machine_downloader/tidy_bytes.rb
+++ b/lib/wayback_machine_downloader/tidy_bytes.rb
@@ -1,4 +1,6 @@
-module TidyBytes
+class WaybackMachineDownloader; end
+
+module WaybackMachineDownloader::TidyBytes
 
   # CP-1252 decimal byte => UTF-8 approximation as an array of bytes
   CP1252 = {
@@ -111,12 +113,12 @@ module TidyBytes
     private
 
     def tidy_byte(byte)
-      byte < 160 ? TidyBytes::CP1252[byte] : byte < 192 ? [194, byte] : [195, byte - 64]
+      byte < 160 ? CP1252[byte] : byte < 192 ? [194, byte] : [195, byte - 64]
     end
 
   end
 end
 
 class String
-  include TidyBytes::StringMixin
+  include WaybackMachineDownloader::TidyBytes::StringMixin
 end

--- a/lib/wayback_machine_downloader/to_regex.rb
+++ b/lib/wayback_machine_downloader/to_regex.rb
@@ -1,4 +1,6 @@
-module ToRegex
+class WaybackMachineDownloader; end
+
+module WaybackMachineDownloader::ToRegex
   module StringMixin
     class << self
       def literal?(str)
@@ -77,5 +79,5 @@ module ToRegex
 end
 
 class String
-  include ToRegex::StringMixin
+  include WaybackMachineDownloader::ToRegex::StringMixin
 end


### PR DESCRIPTION
This is a good practice in general, and is the first step in a transformation implementation for #6 etc.

Also fixes misspelled TidyBytes module name.