### PR TITLE
Escape url to support idn domain names

### DIFF
--- a/lib/wayback_machine_downloader/archive_api.rb
+++ b/lib/wayback_machine_downloader/archive_api.rb
@@ -5,7 +5,7 @@ module ArchiveAPI
     request_url += url
     request_url += parameters_for_api page_index
 
-    open(request_url).read
+    open(URI.escape(request_url)).read
   end
 
   def parameters_for_api page_index


### PR DESCRIPTION
When I tried to download an archive of `.рф` website, I got an error: 
```
Getting snapshot pages/usr/local/Cellar/ruby/2.4.1_1/lib/ruby/2.4.0/uri/rfc3986_parser.rb:21:in `split': URI must be ascii only "url follows"...
```

This PR seems to fix everything and I managed to successfully download an archive.