### PR TITLE
Added a 4 second delay per download due to rate-limiting

### DIFF
--- a/lib/wayback_machine_downloader.rb
+++ b/lib/wayback_machine_downloader.rb
@@ -244,6 +244,7 @@ class WaybackMachineDownloader
   end
 
   def download_file file_remote_info
+    sleep(4)
     current_encoding = "".encoding
     file_url = file_remote_info[:file_url].encode(current_encoding)
     file_id = file_remote_info[:file_id]


### PR DESCRIPTION
Fixes #264 (15 requests per minute rate-limit by archive.org) by adding a 4-second delay between every download. This is currently a bit of a hack - there should probably be a configurable delay parameter. I'm not good enough at Ruby to implement this in its best form, so someone else should add features like that in another pull request if they want to.

Still, since this library is currently non-functional due to the rate limit, we should just fix it in the simplest way possible right now - by merging this pull request.